### PR TITLE
SAML-14: Fixed fatal error due to course shortname.

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -224,7 +224,8 @@ if ($ADMIN->fulltree) {
     );
 
     foreach (get_courses() as $course) {
-        $name = 'auth_saml/course_mapping_'.strtolower($course->shortname);
+        $clean = substr(preg_replace('/[^a-z0-9_]/i', '', $course->shortname), 0, 60);
+        $name = 'auth_saml/course_mapping_'.strtolower($clean);
         $title = $course->shortname;
         if (!empty($course->idnumber)) {
             $title .=' - '.$course->idnumber;


### PR DESCRIPTION
A fatal error could be triggered by course shortnames with
characters that are valid in shortnames but not valid in
admin settings.  Invalid characters will now be filtered out.