### PR TITLE
Remove special chars from generated admin-settings-name.

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -257,7 +257,8 @@ if ($ADMIN->fulltree) {
             if ($course->id == SITEID) {
                 continue;
             }
-            $name = 'auth_saml/course_mapping_'.strtolower($course->shortname);
+            $shortname = preg_replace("^[a-zA-Z0-9_]", "", strtolower($course->shortname)); 
+            $name = 'auth_saml/course_mapping_'.$shortname;
             $title = $course->shortname;
             if (!empty($course->idnumber)) {
                 $title .= ' - ' . $course->idnumber;


### PR DESCRIPTION
We have to generate admin-setting-names that are compatible with moodle core otherwise they will throw an exception. 

see moodle/lib/adminlib.php:1700

`if (!preg_match('/^[a-zA-Z0-9_]+$/', $this->name)) {
    throw new moodle_exception('invalidadminsettingname', '', '', $name);
}`


